### PR TITLE
Add simple Vue and Tailwind translation UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+config.js
+node_modules/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Multi Translate
+
+A simple client-side translation app built with Vue 3 and Tailwind CSS. It relies on the [LibreTranslate](https://libretranslate.com) API by default, but you can point it to any translation service that accepts the same request format.
+
+## Setup
+
+1. Copy `config.sample.js` to `config.js` and adjust the API endpoint or API key if required:
+   ```bash
+   cp config.sample.js config.js
+   # edit config.js
+   ```
+2. Open `index.html` in your browser.
+
+The app does not require a build step or backend server; everything runs directly in the browser.
+
+## Security Notes
+
+`config.js` is ignored by git so that your API key stays out of version control. Keep the file private if you include sensitive credentials.
+

--- a/app.js
+++ b/app.js
@@ -1,0 +1,58 @@
+const { createApp } = Vue;
+
+// Load config safely
+import('./config.js')
+  .catch(() => import('./config.sample.js'))
+  .then(module => {
+    const config = module.default;
+
+    createApp({
+      data() {
+        return {
+          text: '',
+          sourceLang: 'en',
+          targetLang: 'es',
+          translated: '',
+          loading: false,
+          languages: {
+            en: 'English',
+            es: 'Spanish',
+            fr: 'French',
+            de: 'German',
+            it: 'Italian',
+            ja: 'Japanese',
+            zh: 'Chinese',
+          },
+        };
+      },
+      methods: {
+        async translate() {
+          if (!this.text.trim()) return;
+          this.loading = true;
+          this.translated = '';
+          try {
+            const response = await fetch(`${config.API_URL}/translate`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                ...(config.API_KEY ? { 'Authorization': `Bearer ${config.API_KEY}` } : {}),
+              },
+              body: JSON.stringify({
+                q: this.text,
+                source: this.sourceLang,
+                target: this.targetLang,
+                format: 'text',
+              }),
+            });
+            const data = await response.json();
+            this.translated = data.translatedText || data.data?.translations?.[0]?.translatedText || '';
+          } catch (err) {
+            console.error(err);
+            alert('Translation failed.');
+          } finally {
+            this.loading = false;
+          }
+        },
+      },
+    }).mount('#app');
+  });

--- a/config.sample.js
+++ b/config.sample.js
@@ -1,0 +1,4 @@
+export default {
+  API_URL: 'https://libretranslate.com',
+  API_KEY: '', // optional
+};

--- a/index.html
+++ b/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Multi Translate</title>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen flex items-center justify-center p-4">
+  <div id="app" class="max-w-xl w-full bg-white shadow-lg rounded-lg p-6">
+    <h1 class="text-2xl font-bold mb-4 text-center">Multi Translate</h1>
+    <div class="mb-4">
+      <label class="block text-gray-700">Source Language:</label>
+      <select v-model="sourceLang" class="mt-1 block w-full border-gray-300 rounded-md" :disabled="loading">
+        <option v-for="(name, code) in languages" :value="code">{{ name }}</option>
+      </select>
+    </div>
+    <div class="mb-4">
+      <label class="block text-gray-700">Target Language:</label>
+      <select v-model="targetLang" class="mt-1 block w-full border-gray-300 rounded-md" :disabled="loading">
+        <option v-for="(name, code) in languages" :value="code">{{ name }}</option>
+      </select>
+    </div>
+    <div class="mb-4">
+      <label class="block text-gray-700">Text:</label>
+      <textarea v-model="text" rows="4" class="mt-1 block w-full border-gray-300 rounded-md" :disabled="loading"></textarea>
+    </div>
+    <button @click="translate" class="w-full py-2 px-4 bg-blue-600 text-white rounded-md hover:bg-blue-700" :disabled="loading">
+      {{ loading ? 'Translating...' : 'Translate' }}
+    </button>
+    <div v-if="translated" class="mt-4">
+      <label class="block text-gray-700">Translation:</label>
+      <pre class="mt-1 p-2 bg-gray-100 rounded-md whitespace-pre-wrap">{{ translated }}</pre>
+    </div>
+  </div>
+
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a `.gitignore`
- build a single page Vue app using Tailwind
- load translation API settings from `config.js` (ignored) with sample
- document how to run the app

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686813f28344832cbfe2edb562409ddd