### PR TITLE
Add Express proxy server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,27 @@
 # Multi Translate
 
 A simple client-side translation app built with Vue 3 and Tailwind CSS. It now
-uses the [DeepL](https://www.deepl.com/) API for translations.
+uses the [DeepL](https://www.deepl.com/) API for translations. Direct calls to
+DeepL from the browser are blocked by CORS, so a small Node.js proxy server is
+included.
 
 ## Setup
 
-1. Copy `config.sample.js` to `config.js`, add your DeepL authentication key,
-   and adjust `API_URL` if you're using the paid API endpoint:
+1. Copy `config.sample.js` to `config.js` and add your DeepL authentication key:
    ```bash
    cp config.sample.js config.js
    # edit config.js
    ```
-2. Open `index.html` in your browser.
+   `API_URL` already points to the local proxy server (`http://localhost:3000`).
 
-The app does not require a build step or backend server; everything runs directly in the browser.
+2. Install dependencies and start the server:
+   ```bash
+   npm install
+   node server.js
+   ```
+   The server listens on port `3000` by default and forwards requests to DeepL.
+
+3. Open `index.html` in your browser.
 
 ## Security Notes
 

--- a/config.sample.js
+++ b/config.sample.js
@@ -1,7 +1,7 @@
 export default {
-  // Base URL for the DeepL API. Change to `https://api.deepl.com/v2` if you
-  // have a paid account.
-  API_URL: 'https://api-free.deepl.com/v2',
+  // URL for the local proxy server. The proxy forwards requests to the DeepL
+  // API so browser CORS restrictions are avoided.
+  API_URL: 'http://localhost:3000',
   // Your DeepL authentication key. Required for requests.
   API_KEY: '',
 };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "multi-translate",
+  "version": "1.0.0",
+  "description": "A simple client-side translation app built with Vue 3 and Tailwind CSS. It now uses the [DeepL](https://www.deepl.com/) API for translations.",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const cors = require('cors');
+
+const API_URL = process.env.API_URL || 'https://api-free.deepl.com/v2';
+const API_KEY = process.env.API_KEY || '';
+
+const app = express();
+app.use(cors());
+app.use(express.urlencoded({ extended: true }));
+app.use(express.json());
+
+app.post('/translate', async (req, res) => {
+  const { text, source_lang, target_lang } = req.body;
+  const params = new URLSearchParams();
+  if (API_KEY) params.append('auth_key', API_KEY);
+  if (text) params.append('text', text);
+  if (source_lang) params.append('source_lang', source_lang.toUpperCase());
+  if (target_lang) params.append('target_lang', target_lang.toUpperCase());
+
+  try {
+    const response = await fetch(`${API_URL}/translate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString(),
+    });
+    const data = await response.json();
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Translation failed' });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => console.log(`Server listening on port ${port}`));


### PR DESCRIPTION
## Summary
- add Node server to proxy DeepL API requests
- point sample config to the new local server
- create package.json with server dependencies
- update README with updated setup instructions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6888f8ca3fd0832ca2be4b7e5805a56e