### PR TITLE
Allow translating into multiple languages

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,21 +17,26 @@
       </select>
     </div>
     <div class="mb-4">
-      <label class="block text-gray-700">Target Language:</label>
-      <select v-model="targetLang" class="mt-1 block w-full border-gray-300 rounded-md" :disabled="loading">
+      <label class="block text-gray-700">Target Languages:</label>
+      <select multiple v-model="targetLangs" class="mt-1 block w-full border-gray-300 rounded-md" :disabled="loading">
         <option v-for="(name, code) in languages" :value="code">{{ name }}</option>
       </select>
     </div>
     <div class="mb-4">
       <label class="block text-gray-700">Text:</label>
-      <textarea v-model="text" rows="4" class="mt-1 block w-full border-gray-300 rounded-md" :disabled="loading"></textarea>
+      <textarea v-model="text" rows="4" class="mt-1 block w-full border-2 border-blue-500 rounded-md focus:ring-2 focus:ring-blue-500" :disabled="loading"></textarea>
     </div>
     <button @click="translate" class="w-full py-2 px-4 bg-blue-600 text-white rounded-md hover:bg-blue-700" :disabled="loading">
       {{ loading ? 'Translating...' : 'Translate' }}
     </button>
-    <div v-if="translated" class="mt-4">
-      <label class="block text-gray-700">Translation:</label>
-      <pre class="mt-1 p-2 bg-gray-100 rounded-md whitespace-pre-wrap">{{ translated }}</pre>
+    <div v-if="Object.keys(translations).length" class="mt-4">
+      <label class="block text-gray-700 mb-2">Translations:</label>
+      <ul>
+        <li v-for="(text, code) in translations" class="mb-2">
+          <strong>{{ languages[code] }}:</strong>
+          <pre class="mt-1 p-2 bg-gray-100 rounded-md whitespace-pre-wrap inline-block w-full">{{ text }}</pre>
+        </li>
+      </ul>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary
- allow picking multiple target languages
- display each language's translation in a list
- tweak textarea styling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68891a20ee58832cbce8163d4919bc1a