### PR TITLE
Improve mobile target language selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,9 +18,17 @@
     </div>
     <div class="mb-4">
       <label class="block text-gray-700">Target Languages:</label>
-      <select multiple v-model="targetLangs" class="mt-1 block w-full border-gray-300 rounded-md" :disabled="loading">
-        <option v-for="(name, code) in languages" :value="code">{{ name }}</option>
-      </select>
+      <div class="flex flex-wrap gap-2 my-2" v-if="targetLangs.length">
+        <span v-for="code in targetLangs" :key="code" class="px-2 py-1 bg-blue-600 text-white rounded">
+          {{ languages[code] }}
+        </span>
+      </div>
+      <div class="grid grid-cols-2 gap-2">
+        <label v-for="(name, code) in languages" :key="code" class="flex items-center">
+          <input type="checkbox" :value="code" v-model="targetLangs" class="mr-2" :disabled="loading"/>
+          <span>{{ name }}</span>
+        </label>
+      </div>
     </div>
     <div class="mb-4">
       <label class="block text-gray-700">Text:</label>


### PR DESCRIPTION
## Summary
- replace multi-select with mobile-friendly checkboxes for target languages
- show selected target languages as labeled chips

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68891c241234832cbd987fd260c02f7d