### PR TITLE
Replace language checkboxes with multi-select list

### DIFF
--- a/app.js
+++ b/app.js
@@ -85,6 +85,10 @@ import('./config.js')
             this.loading = false;
           }
         },
+
+        clearTargets() {
+          this.targetLangs = [];
+        },
       },
     }).mount('#app');
   });

--- a/index.html
+++ b/index.html
@@ -17,18 +17,20 @@
       </select>
     </div>
     <div class="mb-4">
-      <label class="block text-gray-700">Target Languages:</label>
+      <div class="flex items-center justify-between">
+        <label class="block text-gray-700">Target Languages:</label>
+        <button @click="clearTargets" class="text-xs text-blue-600 hover:underline" :disabled="loading || !targetLangs.length">Clear</button>
+      </div>
       <div class="flex flex-wrap gap-2 my-2" v-if="targetLangs.length">
         <span v-for="code in targetLangs" :key="code" class="px-2 py-1 bg-blue-600 text-white rounded">
           {{ languages[code] }}
         </span>
       </div>
-      <div class="grid grid-cols-2 gap-2">
-        <label v-for="(name, code) in languages" :key="code" class="flex items-center">
-          <input type="checkbox" :value="code" v-model="targetLangs" class="mr-2" :disabled="loading"/>
-          <span>{{ name }}</span>
-        </label>
-      </div>
+      <select v-model="targetLangs" multiple size="8" class="mt-1 block w-full border-gray-300 rounded-md" :disabled="loading">
+        <option v-for="(name, code) in languages" :key="code" :value="code">
+          {{ name }}
+        </option>
+      </select>
     </div>
     <div class="mb-4">
       <label class="block text-gray-700">Text:</label>


### PR DESCRIPTION
## Summary
- switch target language checkboxes to a `<select>` element
- add `Clear` button to reset selected target languages

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_68891d3ab074832c8cd0b32f33692905