### PR TITLE
Add CI workflow and Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log
+config.js
+.git
+.github

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      API_KEY: ${{ secrets.DEEPL_API_KEY }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npm test
+      - name: Build Docker image
+        run: docker build -t multi-translate .
+      - name: Run container for smoke test
+        run: |
+          docker run -d --name app -e API_KEY=$API_KEY -p 3000:3000 multi-translate
+          sleep 5
+          docker ps -a
+          docker logs app
+          docker rm -f app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+# Use Node 18 LTS
+FROM node:18-alpine
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install dependencies
+COPY package*.json ./
+RUN npm ci --only=production
+
+# Copy application files
+COPY . .
+
+# Expose the port used by the server
+EXPOSE 3000
+
+# Start the server
+CMD [ "node", "server.js" ]

--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ included.
    ```
    The server listens on port `3000` by default and forwards requests to DeepL.
 
+### Docker
+
+You can also run the server using Docker:
+
+```bash
+docker build -t multi-translate .
+docker run -p 3000:3000 -e API_KEY=your-key multi-translate
+```
+
+### GitHub Actions
+
+This repository includes a workflow at `.github/workflows/ci.yml` which
+automatically installs dependencies, runs the (minimal) test suite and builds a
+Docker image on every push or pull request. Set the `DEEPL_API_KEY` repository
+secret with your DeepL authentication key so the workflow can start the server
+for a smoke test.
+
 3. Open `index.html` in your browser.
 
 ## Security Notes

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple client-side translation app built with Vue 3 and Tailwind CSS. It now uses the [DeepL](https://www.deepl.com/) API for translations.",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node tests/smoke.js",
     "start": "node server.js"
   },
   "keywords": [],

--- a/tests/smoke.js
+++ b/tests/smoke.js
@@ -1,0 +1,24 @@
+const { spawn } = require('child_process');
+const http = require('http');
+
+const child = spawn('node', ['server.js'], {
+  env: { ...process.env, PORT: 4000 },
+  stdio: 'inherit'
+});
+
+setTimeout(() => {
+  http.get('http://localhost:4000/', res => {
+    child.kill();
+    if (res.statusCode === 404) {
+      console.log('Server started');
+      process.exit(0);
+    } else {
+      console.error('Unexpected status', res.statusCode);
+      process.exit(1);
+    }
+  }).on('error', err => {
+    child.kill();
+    console.error(err);
+    process.exit(1);
+  });
+}, 1000);


### PR DESCRIPTION
## Summary
- add Dockerfile and .dockerignore to containerize the server
- create GitHub Actions workflow running tests and building the Docker image
- add a small smoke test for server start
- update README with Docker and workflow details
- adjust `package.json` test script

## Testing
- `npm test` *(fails: Cannot find module 'express' because dependencies can't be installed)*

------
https://chatgpt.com/codex/tasks/task_e_688920f35ff4832cb533023e58bd434c