### PR TITLE
Add button to append target languages

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ import('./config.js')
           text: '',
           sourceLang: 'fr',
           targetLangs: ['en'],
+          selectedLang: 'en',
           translations: {},
           loading: false,
           sourceLanguages: {
@@ -119,6 +120,12 @@ import('./config.js')
 
         clearTargets() {
           this.targetLangs = [];
+        },
+
+        addTarget() {
+          if (this.selectedLang && !this.targetLangs.includes(this.selectedLang)) {
+            this.targetLangs.push(this.selectedLang);
+          }
         },
       },
     }).mount('#app');

--- a/index.html
+++ b/index.html
@@ -26,11 +26,16 @@
           {{ languages[code] }}
         </span>
       </div>
-      <select v-model="targetLangs" multiple size="8" class="mt-1 block w-full border-gray-300 rounded-md" :disabled="loading">
-        <option v-for="(name, code) in languages" :key="code" :value="code">
-          {{ name }}
-        </option>
-      </select>
+      <div class="flex items-center mt-1">
+        <select v-model="selectedLang" class="block w-full border-gray-300 rounded-md" :disabled="loading">
+          <option v-for="(name, code) in languages" :key="code" :value="code">
+            {{ name }}
+          </option>
+        </select>
+        <button @click="addTarget" class="ml-2 px-3 py-1 bg-blue-600 text-white rounded" :disabled="loading || targetLangs.includes(selectedLang)">
+          Add
+        </button>
+      </div>
     </div>
     <div class="mb-4">
       <label class="block text-gray-700">Text:</label>


### PR DESCRIPTION
## Summary
- select a language then click `Add` instead of using multi-select
- expose `selectedLang` state and `addTarget` method

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688920680ac0832c9852b064f230ef2d