### PR TITLE
Add auto-detect source language

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 A simple client-side translation app built with Vue 3 and Tailwind CSS. It now
 uses the [DeepL](https://www.deepl.com/) API for translations. Direct calls to
 DeepL from the browser are blocked by CORS, so a small Node.js proxy server is
-included.
+included. The source language is set to **Auto‑Detect** by default so you can
+paste any text without choosing a language first.
 
 ## Setup
 

--- a/app.js
+++ b/app.js
@@ -10,11 +10,12 @@ import('./config.js')
       data() {
         return {
           text: '',
-          sourceLang: 'fr',
+          sourceLang: 'auto',
           targetLangs: ['en'],
           translations: {},
           loading: false,
           sourceLanguages: {
+            auto: 'Auto-Detect',
             bg: 'Bulgarian',
             cs: 'Czech',
             da: 'Danish',
@@ -91,7 +92,9 @@ import('./config.js')
               const params = new URLSearchParams();
               if (config.API_KEY) params.append('auth_key', config.API_KEY);
               params.append('text', this.text);
-              if (this.sourceLang) params.append('source_lang', this.sourceLang.toUpperCase());
+              if (this.sourceLang && this.sourceLang !== 'auto') {
+                params.append('source_lang', this.sourceLang.toUpperCase());
+              }
               params.append('target_lang', lang.toUpperCase());
 
               const response = await fetch(`${config.API_URL}/translate`, {

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <div id="app" class="max-w-xl w-full bg-white shadow-lg rounded-lg p-6">
     <h1 class="text-2xl font-bold mb-4 text-center">Multi Translate</h1>
     <div class="mb-4">
-      <label class="block text-gray-700">Source Language:</label>
+      <label class="block text-gray-700">Source Language (auto-detect by default):</label>
       <select v-model="sourceLang" class="mt-1 block w-full border-gray-300 rounded-md" :disabled="loading">
         <option v-for="(name, code) in sourceLanguages" :value="code">{{ name }}</option>
       </select>


### PR DESCRIPTION
## Summary
- auto-select source language by default
- document that Auto-Detect is the default
- show Auto-Detect label in the UI
- omit source_lang parameter when Auto-Detect is chosen

## Testing
- `node -v`
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_688921bb94d8832c96a1778719f4c562