### PR TITLE
Add target language validation

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,6 +16,7 @@ import('./config.js')
           translations: {},
           loading: false,
           darkMode: false,
+          targetLangError: '',
           sourceLanguages: {
             auto: 'Auto-Detect',
             bg: 'Bulgarian',
@@ -86,7 +87,12 @@ import('./config.js')
       },
       methods: {
         async translate() {
-          if (!this.text.trim() || this.targetLangs.length === 0) return;
+          if (!this.text.trim()) return;
+          if (this.targetLangs.length === 0) {
+            this.targetLangError = 'Please select at least one target language.';
+            return;
+          }
+          this.targetLangError = '';
           this.loading = true;
           this.translations = {};
           try {
@@ -124,11 +130,13 @@ import('./config.js')
 
         clearTargets() {
           this.targetLangs = [];
+          this.targetLangError = '';
         },
 
         addTarget() {
           if (this.selectedLang && !this.targetLangs.includes(this.selectedLang)) {
             this.targetLangs.push(this.selectedLang);
+            this.targetLangError = '';
           }
         },
 

--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
           Add
         </button>
       </div>
+      <p v-if="targetLangError" class="text-red-500 text-sm mt-1">{{ targetLangError }}</p>
     </div>
     <div class="mb-4">
       <label class="block text-gray-700">Text:</label>


### PR DESCRIPTION
## Summary
- show validation error when Translate is pressed with no target languages
- keep error cleared when languages are added or cleared

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688926622300832ca88a68b0c2190933