### PR TITLE
Fix dark mode text visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,20 +12,20 @@
   <div class="max-w-xl w-full bg-white dark:bg-gray-800 dark:text-gray-100 shadow-lg rounded-lg p-6">
     <h1 class="text-2xl font-bold mb-2 text-center">Multi Translate</h1>
     <div class="flex justify-end mb-2">
-      <button @click="toggleDarkMode" class="text-sm text-blue-600 hover:underline" :disabled="loading">
+      <button @click="toggleDarkMode" class="text-sm text-blue-600 dark:text-blue-400 hover:underline" :disabled="loading">
         {{ darkMode ? 'Light Mode' : 'Dark Mode' }}
       </button>
     </div>
     <div class="mb-4">
-      <label class="block text-gray-700">Source Language (auto-detect by default):</label>
+      <label class="block text-gray-700 dark:text-gray-300">Source Language (auto-detect by default):</label>
       <select v-model="sourceLang" class="mt-1 block w-full border-gray-300 rounded-md" :disabled="loading">
         <option v-for="(name, code) in sourceLanguages" :value="code">{{ name }}</option>
       </select>
     </div>
     <div class="mb-4">
       <div class="flex items-center justify-between">
-        <label class="block text-gray-700">Target Languages:</label>
-        <button @click="clearTargets" class="text-xs text-blue-600 hover:underline" :disabled="loading || !targetLangs.length">Clear</button>
+        <label class="block text-gray-700 dark:text-gray-300">Target Languages:</label>
+        <button @click="clearTargets" class="text-xs text-blue-600 dark:text-blue-400 hover:underline" :disabled="loading || !targetLangs.length">Clear</button>
       </div>
       <div class="flex flex-wrap gap-2 my-2" v-if="targetLangs.length">
         <span v-for="code in targetLangs" :key="code" class="flex items-center px-2 py-1 bg-blue-600 text-white rounded">
@@ -43,24 +43,24 @@
           Add
         </button>
       </div>
-      <p v-if="targetLangError" class="text-red-500 text-sm mt-1">{{ targetLangError }}</p>
+      <p v-if="targetLangError" class="text-red-500 dark:text-red-400 text-sm mt-1">{{ targetLangError }}</p>
     </div>
     <div class="mb-4">
-      <label class="block text-gray-700">Text:</label>
+      <label class="block text-gray-700 dark:text-gray-300">Text:</label>
       <textarea v-model="text" rows="4" class="mt-1 block w-full border-2 border-blue-500 rounded-md focus:ring-2 focus:ring-blue-500" :disabled="loading" placeholder="Enter text to translate"></textarea>
     </div>
     <button @click="translate" class="w-full py-2 px-4 bg-blue-600 text-white rounded-md hover:bg-blue-700" :disabled="loading">
       {{ loading ? 'Translating...' : 'Translate' }}
     </button>
       <div v-if="Object.keys(translations).length" class="mt-4">
-        <label class="block text-gray-700 mb-2">Translations:</label>
+        <label class="block text-gray-700 dark:text-gray-300 mb-2">Translations:</label>
         <ul>
           <li v-for="(text, code) in translations" class="mb-2">
             <div class="flex justify-between items-center">
               <strong>{{ languages[code] }}:</strong>
-              <button @click="copyTranslation(text)" class="text-xs text-blue-600 hover:underline">Copy</button>
+              <button @click="copyTranslation(text)" class="text-xs text-blue-600 dark:text-blue-400 hover:underline">Copy</button>
             </div>
-            <pre class="mt-1 p-2 bg-gray-100 rounded-md whitespace-pre-wrap inline-block w-full">{{ text }}</pre>
+            <pre class="mt-1 p-2 bg-gray-100 dark:bg-gray-700 rounded-md whitespace-pre-wrap inline-block w-full">{{ text }}</pre>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- add dark mode text colors for better contrast

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6889280955ec832c895e5b953184e996