### PR TITLE
Fix dark theme text styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     </div>
     <div class="mb-4">
       <label class="block text-gray-700 dark:text-gray-300">Source Language (auto-detect by default):</label>
-      <select v-model="sourceLang" class="mt-1 block w-full border-gray-300 rounded-md" :disabled="loading">
+      <select v-model="sourceLang" class="mt-1 block w-full border-gray-300 rounded-md dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600" :disabled="loading">
         <option v-for="(name, code) in sourceLanguages" :value="code">{{ name }}</option>
       </select>
     </div>
@@ -34,7 +34,7 @@
         </span>
       </div>
       <div class="flex items-center mt-1">
-        <select v-model="selectedLang" class="block w-full border-gray-300 rounded-md" :disabled="loading">
+        <select v-model="selectedLang" class="block w-full border-gray-300 rounded-md dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600" :disabled="loading">
           <option v-for="(name, code) in languages" :key="code" :value="code">
             {{ name }}
           </option>
@@ -47,7 +47,7 @@
     </div>
     <div class="mb-4">
       <label class="block text-gray-700 dark:text-gray-300">Text:</label>
-      <textarea v-model="text" rows="4" class="mt-1 block w-full border-2 border-blue-500 rounded-md focus:ring-2 focus:ring-blue-500" :disabled="loading" placeholder="Enter text to translate"></textarea>
+      <textarea v-model="text" rows="4" class="mt-1 block w-full border-2 border-blue-500 rounded-md focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-gray-100" :disabled="loading" placeholder="Enter text to translate"></textarea>
     </div>
     <button @click="translate" class="w-full py-2 px-4 bg-blue-600 text-white rounded-md hover:bg-blue-700" :disabled="loading">
       {{ loading ? 'Translating...' : 'Translate' }}
@@ -60,7 +60,7 @@
               <strong>{{ languages[code] }}:</strong>
               <button @click="copyTranslation(text)" class="text-xs text-blue-600 dark:text-blue-400 hover:underline">Copy</button>
             </div>
-            <pre class="mt-1 p-2 bg-gray-100 dark:bg-gray-700 rounded-md whitespace-pre-wrap inline-block w-full">{{ text }}</pre>
+            <pre class="mt-1 p-2 bg-gray-100 dark:bg-gray-700 dark:text-gray-100 rounded-md whitespace-pre-wrap inline-block w-full">{{ text }}</pre>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
## Summary
- fix dark mode colors for dropdowns
- apply dark theme color to textarea and translation output

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68892912dd88832cacde389c8f6fa0f2