### PR TITLE
Enable dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,22 @@ paste any text without choosing a language first.
    ```
    `API_URL` already points to the local proxy server (`http://localhost:3000`).
 
-2. Install dependencies and start the server:
+2. Create a `.env` file (or export variables in your shell) to provide your
+   DeepL API configuration:
+
+   ```bash
+   echo "API_KEY=your_key" > .env
+   echo "API_URL=https://api-free.deepl.com/v2" >> .env
+   ```
+
+3. Install dependencies and start the server:
    ```bash
    npm install
    node server.js
    ```
    The server listens on port `3000` by default and forwards requests to DeepL.
 
-3. Open `index.html` in your browser.
+4. Open `index.html` in your browser.
 
 ## Security Notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",
+        "dotenv": "^17.2.1",
         "express": "^4.18.2"
       }
     },
@@ -169,6 +170,18 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "type": "commonjs",
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "dotenv": "^17.2.1"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const path = require('path');
+require('dotenv').config();
 
 const API_URL = process.env.API_URL || 'https://api-free.deepl.com/v2';
 const SERVER_API_KEY = process.env.API_KEY || '';


### PR DESCRIPTION
## Summary
- load environment variables from `.env`
- document `.env` setup in README
- install dotenv dependency

## Testing
- `npm test` *(fails: no test specified)*
- `node server.js` *(started and logged dotenv message)*

------
https://chatgpt.com/codex/tasks/task_e_688937a71458832cb0399871979dd77a