### PR TITLE
Remove config files and rely on env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-config.js
 node_modules/
 .DS_Store
 .direnv
+.env

--- a/README.md
+++ b/README.md
@@ -8,16 +8,7 @@ paste any text without choosing a language first.
 
 ## Setup
 
-1. Copy `config.sample.js` to `config.js` and add your DeepL authentication key
-   (optional, the server can also use an `API_KEY` environment variable):
-
-   ```bash
-   cp config.sample.js config.js
-   # edit config.js
-   ```
-   `API_URL` already points to the local proxy server (`http://localhost:3000`).
-
-2. Create a `.env` file (or export variables in your shell) to provide your
+1. Create a `.env` file (or export variables in your shell) to provide your
    DeepL API configuration:
 
    ```bash
@@ -25,16 +16,16 @@ paste any text without choosing a language first.
    echo "API_URL=https://api-free.deepl.com/v2" >> .env
    ```
 
-3. Install dependencies and start the server:
+2. Install dependencies and start the server:
    ```bash
    npm install
    node server.js
    ```
    The server listens on port `3000` by default and forwards requests to DeepL.
 
-4. Open `index.html` in your browser.
+3. Open `index.html` in your browser.
 
 ## Security Notes
 
-`config.js` is ignored by git so that your API key stays out of version control. Keep the file private if you include sensitive credentials.
+The `.env` file is ignored by git so that your API key stays out of version control. Keep the file private if you include sensitive credentials.
 

--- a/app.js
+++ b/app.js
@@ -1,12 +1,6 @@
 const { createApp } = Vue;
 
-// Load config safely
-import('./config.js')
-  .catch(() => import('./config.sample.js'))
-  .then(module => {
-    const config = module.default;
-
-    createApp({
+createApp({
       data() {
         return {
           text: '',
@@ -99,14 +93,13 @@ import('./config.js')
           try {
             const promises = this.targetLangs.map(async lang => {
               const params = new URLSearchParams();
-              if (config.API_KEY) params.append('auth_key', config.API_KEY);
               params.append('text', this.text);
               if (this.sourceLang && this.sourceLang !== 'auto') {
                 params.append('source_lang', this.sourceLang.toUpperCase());
               }
               params.append('target_lang', lang.toUpperCase());
 
-              const response = await fetch(`${config.API_URL}/translate`, {
+              const response = await fetch('/translate', {
                 method: 'POST',
                 headers: {
                   'Content-Type': 'application/x-www-form-urlencoded',
@@ -206,4 +199,3 @@ import('./config.js')
         },
       },
     }).mount('#app');
-  });

--- a/config.sample.js
+++ b/config.sample.js
@@ -1,8 +1,0 @@
-export default {
-  // URL for the local proxy server. The proxy forwards requests to the DeepL
-  // API so browser CORS restrictions are avoided.
-  API_URL: 'http://localhost:3000',
-  // Your DeepL authentication key. Can be left blank if you start the server
-  // with the `API_KEY` environment variable set.
-  API_KEY: '',
-};

--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ const path = require('path');
 require('dotenv').config();
 
 const API_URL = process.env.API_URL || 'https://api-free.deepl.com/v2';
-const SERVER_API_KEY = process.env.API_KEY || '';
+const API_KEY = process.env.API_KEY || '';
 
 const app = express();
 app.use(cors());
@@ -17,10 +17,9 @@ app.get('/', (req, res) => {
 });
 
 app.post('/translate', async (req, res) => {
-  const { text, source_lang, target_lang, auth_key } = req.body;
+  const { text, source_lang, target_lang } = req.body;
   const params = new URLSearchParams();
-  const key = SERVER_API_KEY || auth_key;
-  if (key) params.append('auth_key', key);
+  if (API_KEY) params.append('auth_key', API_KEY);
   if (text) params.append('text', text);
   if (source_lang) params.append('source_lang', source_lang.toUpperCase());
   if (target_lang) params.append('target_lang', target_lang.toUpperCase());


### PR DESCRIPTION
## Summary
- remove `config.sample.js`
- stop loading optional client config and call proxy at `/translate`
- read DeepL config solely from environment variables
- ignore `.env` in git
- update README setup instructions

## Testing
- `npm install`
- `npm test` *(fails: Error: no test specified)*
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68894b60a450832c81dcfd953f152230